### PR TITLE
Add support to override web.xml descriptor configuration using maven property

### DIFF
--- a/pinery-ws/pom.xml
+++ b/pinery-ws/pom.xml
@@ -13,6 +13,7 @@
     <packaging>war</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <overrideDescriptor></overrideDescriptor>
     </properties>
     <dependencies>
         <!-- RESTEasy dependencies (keep at top to prevent NoSuchMethodErrors on some Tomcat versions) -->
@@ -64,15 +65,18 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.mortbay.jetty</groupId>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <configuration>
-                    <connectors>
-                        <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
-                            <port>8888</port>
-                            <maxIdleTime>60000</maxIdleTime>
-                        </connector>
-                    </connectors>
+                    <httpConnector> 
+                        <port>8888</port>
+                        <idleTimeout>60000</idleTimeout>
+                    </httpConnector>
+                    <webApp>
+                        <contextPath>/pinery-ws</contextPath>
+                        <!-- this overrides or adds configuration from web.xml-->
+                        <overrideDescriptor>${overrideDescriptor}</overrideDescriptor>
+                    </webApp>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
       <log4j.version>1.2.16</log4j.version>
       <joda-time.version>2.1</joda-time.version>
       <maven-assembly-plugin.version>2.3</maven-assembly-plugin.version>
-      <jetty-maven-plugin.version>7.0.0.pre5</jetty-maven-plugin.version>
+      <jetty-maven-plugin.version>9.3.7.v20160115</jetty-maven-plugin.version>
       <findbugs-maven-plugin.version>2.5.2</findbugs-maven-plugin.version>
       <maven-pmd-plugin.version>2.7.1</maven-pmd-plugin.version>
    </properties>
@@ -266,9 +266,9 @@
                <version>${maven-assembly-plugin.version}</version>
             </plugin>
             <plugin>
-               <groupId>org.mortbay.jetty</groupId>
-               <artifactId>jetty-maven-plugin</artifactId>
-               <version>${jetty-maven-plugin.version}</version>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty-maven-plugin.version}</version>
             </plugin>
             <plugin>
                <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
- For example: mvn jetty:run -DoverrideDescriptor=/path/to/custom/web.xml
- Update jetty-maven-plugin from 7.0.0 to 9.3.7